### PR TITLE
Fix child linkage when the child problem is solved

### DIFF
--- a/src/task.cpp
+++ b/src/task.cpp
@@ -208,6 +208,8 @@ void Task::send_explorer(Task const & child, float scope, int feature, unsigned 
         State::graph.vertices.find(child, key -> second);
         if (scope < child -> second.upperscope()) {
             adjacency_accessor parents;
+            State::graph.translations.insert(std::make_pair(std::make_pair(this -> identifier(), feature), order())); // insert translation
+            State::graph.children.insert(std::make_pair(std::make_pair(this -> identifier(), feature), key -> second)); // insert forward look-up entry
             State::graph.edges.find(parents, child -> second.identifier()); // insert backward look-up entry
             std::pair<adjacency_iterator, bool> insertion = parents -> second.insert(
                 std::make_pair(this -> identifier(), std::make_pair(Bitmask(State::dataset.width(), false), scope)));


### PR DESCRIPTION
When a child problem is solved (as defined by having a scope higher than current problem), current code only inserts backward lookup entry. However, forward lookup entry is required when constructing models from the dependency graph. This in extremely rare cases would lead to missing solutions. This PR fixes this issue by inserting forward lookup entry when we encounter the said case. 