### PR TITLE
Change loss parameter in GradientBoostinClassifier from 'deviance' to 'log_loss'.

### DIFF
--- a/gosdt/model/threshold_guess.py
+++ b/gosdt/model/threshold_guess.py
@@ -16,7 +16,7 @@ from sklearn import metrics
 
 # fit the tree using gradient boosted classifier
 def fit_boosted_tree(X, y, n_est=10, lr=0.1, d=1):
-    clf = GradientBoostingClassifier(loss='deviance', learning_rate=lr, n_estimators=n_est, max_depth=d,
+    clf = GradientBoostingClassifier(loss='log_loss', learning_rate=lr, n_estimators=n_est, max_depth=d,
                                     random_state=42)
     clf.fit(X, y)
     out = clf.score(X, y)


### PR DESCRIPTION
Encountered the following error when running this code:

`X_train_binarized, thresholds, header, threshold_guess_time = gosdt.model.threshold_guess.compute_thresholds(X_train.copy(), y_train, 40, 1)`:
InvalidParameterError: The 'loss' parameter of GradientBoostingClassifier must be a str among {'log_loss', 'exponential'}. Got 'deviance' instead.

Using Python 3.10.12 with the most up to date versions of scikit-learn and gosdt.

Scikit-learn documentation [here](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.GradientBoostingClassifier.html) suggests that 'log_loss' is equivalent to deviance.


