### PR TITLE
Speed up model scoring/prediction for large datasets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
               if: ${{ !startsWith(matrix.config.name, 'Windows') || (startsWith(matrix.config.name, 'Windows') && matrix.config.python-minor-version == 7) }}
               run: |
                   python3 -c "import sys; exit(not (sys.version_info.major == 3 and sys.version_info.minor == 7))"
-                  pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+                  pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
                   python3 -c "import os; import subprocess; exit(subprocess.run(['pip3', 'install', 'dist/{}'.format(os.listdir('dist')[0])]).returncode)"
                   python3 gosdt/example.py
             # Python 3.8: Run the sample experiment
@@ -181,7 +181,7 @@ jobs:
               if: ${{ !startsWith(matrix.config.name, 'Windows') || (startsWith(matrix.config.name, 'Windows') && matrix.config.python-minor-version == 8) }}
               run: |
                   python3 -c "import sys; exit(not (sys.version_info.major == 3 and sys.version_info.minor == 8))"
-                  pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+                  pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
                   python3 -c "import os; import subprocess; exit(subprocess.run(['pip3', 'install', 'dist/{}'.format(os.listdir('dist')[0])]).returncode)"
                   python3 gosdt/example.py
             # Python 3.9: Run the sample experiment
@@ -194,7 +194,7 @@ jobs:
               if: ${{ !startsWith(matrix.config.name, 'Windows') || (startsWith(matrix.config.name, 'Windows') && matrix.config.python-minor-version == 9) }}
               run: |
                   python3 -c "import sys; exit(not (sys.version_info.major == 3 and sys.version_info.minor == 9))"
-                  pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+                  pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
                   python3 -c "import os; import subprocess; exit(subprocess.run(['pip3', 'install', 'dist/{}'.format(os.listdir('dist')[0])]).returncode)"
                   python3 gosdt/example.py
             # Python 3.10: Run the sample experiment
@@ -207,7 +207,7 @@ jobs:
               if: ${{ !startsWith(matrix.config.name, 'Windows') || (startsWith(matrix.config.name, 'Windows') && matrix.config.python-minor-version == 10) }}
               run: |
                   python3 -c "import sys; exit(not (sys.version_info.major == 3 and sys.version_info.minor == 10))"
-                  pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+                  pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
                   python3 -c "import os; import subprocess; exit(subprocess.run(['pip3', 'install', 'dist/{}'.format(os.listdir('dist')[0])]).returncode)"
                   python3 gosdt/example.py
             # Upload the wheel file

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You may use the following commands to install GOSDT along with its dependencies 
 You need **Python 3.7 or later** to use the module `gosdt` in your project.
 
 ```bash
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 pip3 install gosdt
 ```
 

--- a/README_PyPI.md
+++ b/README_PyPI.md
@@ -21,7 +21,7 @@ You may use the following commands to install GOSDT along with its dependencies 
 You need **Python 3.7 or later** to use the module `gosdt` in your project.
 
 ```bash
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 pip3 install gosdt
 ```
 ---

--- a/doc/build.md
+++ b/doc/build.md
@@ -262,6 +262,6 @@ Please adjust the name of your wheel file accordingly.
 
 ```bash
 pip3 install dist/gosdt-1.0.5-cp310-cp310-macosx_12_0_x86_64.whl
-pip3 install attrs packaging editables pandas sklearn sortedcontainers gmpy2 matplotlib
+pip3 install attrs packaging editables pandas scikit-learn sortedcontainers gmpy2 matplotlib
 python3 gosdt/example.py
 ```

--- a/gosdt/model/threshold_guess.py
+++ b/gosdt/model/threshold_guess.py
@@ -1,22 +1,12 @@
 import numpy as np
-import pandas as pd
-import json
 import time
-import random
-import sys
-import os  
-from queue import Queue
-import pathlib
 
-from math import ceil
-from sklearn.model_selection import KFold, cross_val_score, train_test_split
 from sklearn.ensemble import GradientBoostingClassifier
-from sklearn import metrics
 
 
 # fit the tree using gradient boosted classifier
 def fit_boosted_tree(X, y, n_est=10, lr=0.1, d=1):
-    clf = GradientBoostingClassifier(loss='deviance', learning_rate=lr, n_estimators=n_est, max_depth=d,
+    clf = GradientBoostingClassifier(loss='log_loss', learning_rate=lr, n_estimators=n_est, max_depth=d,
                                     random_state=42)
     clf.fit(X, y)
     out = clf.score(X, y)

--- a/gosdt/model/tree_classifier.py
+++ b/gosdt/model/tree_classifier.py
@@ -152,8 +152,9 @@ class TreeClassifier:
         
         predictions = []
         (n, m) = X.shape
+        samples = X.values
         for i in range(n):
-            prediction, _ = self.classify(X.values[i,:])
+            prediction, _ = self.classify(samples[i,:])
             predictions.append(prediction)
         return array(predictions)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "packaging>=20.9",
     "editables==0.2",
     "pandas",
-    "sklearn",
+    "scikit-learn",
     "sortedcontainers",
     "gmpy2",
     "matplotlib"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
                       "packaging>=20.9",
                       "editables==0.2;python_version>'3.0'",
                       "pandas",
-                      "sklearn",
+                      "scikit-learn",
                       "sortedcontainers",
                       "gmpy2",
                       "matplotlib"]


### PR DESCRIPTION
The old classify() code calls X.values for each sample separately. Caching this operation before the loop leads to orders of magnitude speedup for an experiment we recently ran on the Adult dataset from the UCI machine learning repository. 