### PR TITLE
Speed up model scoring/prediction for large datasets

### DIFF
--- a/gosdt/model/tree_classifier.py
+++ b/gosdt/model/tree_classifier.py
@@ -152,8 +152,9 @@ class TreeClassifier:
         
         predictions = []
         (n, m) = X.shape
+        samples = X.values
         for i in range(n):
-            prediction, _ = self.classify(X.values[i,:])
+            prediction, _ = self.classify(samples[i,:])
             predictions.append(prediction)
         return array(predictions)
 


### PR DESCRIPTION
The old classify() code calls X.values for each sample separately. Caching this operation before the loop leads to orders of magnitude speedup for an experiment we recently ran on the Adult dataset from the UCI machine learning repository.