### PR TITLE
Fix scope bug

### DIFF
--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -232,7 +232,7 @@ void Optimizer::store_children(Task &task, unsigned int id) {
             upper = std::min(upper, split_upper);
         }
     }
-    if (lower > this->_upperscope) { return; } // similar reason to check on line 169. If all children out of scope, 
+    if (lower > task.upperscope()) { return; } // similar reason to check on line 169. If all children out of scope, 
                                                // and base risk out of scope, don't update bound.
     task.update(m_config, lower, upper, optimal_feature);
 }

--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -166,7 +166,7 @@ bool Optimizer::load_children(Task &task, Bitmask const &signals, unsigned int i
         lower = std::min(lower, std::get<1>(*iterator));
         upper = std::min(upper, std::get<2>(*iterator));
     }
-    if (lower > task.upperscope()) { return; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
+    if (lower > task.upperscope()) { return False; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
                                                // (In this case, base objective and all splits are all above upper scope, and 
                                                //   no splits were used to update the bounds, though the splits may still have been 
                                                //   better than the base risk). 
@@ -232,7 +232,7 @@ void Optimizer::store_children(Task &task, unsigned int id) {
             upper = std::min(upper, split_upper);
         }
     }
-    if (lower > task.upperscope()) { return; } // similar reason to check on line 169. If all children out of scope, 
+    if (lower > task.upperscope()) { return False; } // similar reason to check on line 169. If all children out of scope, 
                                                // and base risk out of scope, don't update bound.
     task.update(m_config, lower, upper, optimal_feature);
 }

--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -166,10 +166,10 @@ bool Optimizer::load_children(Task &task, Bitmask const &signals, unsigned int i
         lower = std::min(lower, std::get<1>(*iterator));
         upper = std::min(upper, std::get<2>(*iterator));
     }
-    if (lower > task.upperscope()) { return; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
-                                               // (In this case, base objective and all splits are all above upper scope, and 
-                                               //   no splits were used to update the bounds, though the splits may still have been 
-                                               //   better than the base risk). 
+    if (lower > task.upperscope()) { return false; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
+                                                     // (In this case, base objective and all splits are all above upper scope, and 
+                                                     //   no splits were used to update the bounds, though the splits may still have been 
+                                                     //   better than the base risk). 
     return task.update(m_config, lower, upper, optimal_feature);
 }
 
@@ -232,7 +232,7 @@ void Optimizer::store_children(Task &task, unsigned int id) {
             upper = std::min(upper, split_upper);
         }
     }
-    if (lower > task.upperscope()) { return false; } // similar reason to check on line 169. If all children out of scope, 
+    if (lower > task.upperscope()) { return; } // similar reason to check on line 169. If all children out of scope, 
                                                      // and base risk out of scope, don't update bound.
     task.update(m_config, lower, upper, optimal_feature);
 }

--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -166,7 +166,7 @@ bool Optimizer::load_children(Task &task, Bitmask const &signals, unsigned int i
         lower = std::min(lower, std::get<1>(*iterator));
         upper = std::min(upper, std::get<2>(*iterator));
     }
-    if (lower > task.upperscope()) { return false; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
+    if (lower > task.upperscope()) { return; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
                                                // (In this case, base objective and all splits are all above upper scope, and 
                                                //   no splits were used to update the bounds, though the splits may still have been 
                                                //   better than the base risk). 
@@ -233,7 +233,7 @@ void Optimizer::store_children(Task &task, unsigned int id) {
         }
     }
     if (lower > task.upperscope()) { return false; } // similar reason to check on line 169. If all children out of scope, 
-                                               // and base risk out of scope, don't update bound.
+                                                     // and base risk out of scope, don't update bound.
     task.update(m_config, lower, upper, optimal_feature);
 }
 

--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -166,6 +166,10 @@ bool Optimizer::load_children(Task &task, Bitmask const &signals, unsigned int i
         lower = std::min(lower, std::get<1>(*iterator));
         upper = std::min(upper, std::get<2>(*iterator));
     }
+    if (lower > task.upperscope()) { return; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
+                                               // (In this case, base objective and all splits are all above upper scope, and 
+                                               //   no splits were used to update the bounds, though the splits may still have been 
+                                               //   better than the base risk). 
     return task.update(m_config, lower, upper, optimal_feature);
 }
 
@@ -228,6 +232,8 @@ void Optimizer::store_children(Task &task, unsigned int id) {
             upper = std::min(upper, split_upper);
         }
     }
+    if (lower > this->_upperscope) { return; } // similar reason to check on line 169. If all children out of scope, 
+                                               // and base risk out of scope, don't update bound.
     task.update(m_config, lower, upper, optimal_feature);
 }
 

--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -166,7 +166,7 @@ bool Optimizer::load_children(Task &task, Bitmask const &signals, unsigned int i
         lower = std::min(lower, std::get<1>(*iterator));
         upper = std::min(upper, std::get<2>(*iterator));
     }
-    if (lower > task.upperscope()) { return False; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
+    if (lower > task.upperscope()) { return false; } // if lower is > upperscope, then lower may not be a true lower bound b/c of line 160.
                                                // (In this case, base objective and all splits are all above upper scope, and 
                                                //   no splits were used to update the bounds, though the splits may still have been 
                                                //   better than the base risk). 
@@ -232,7 +232,7 @@ void Optimizer::store_children(Task &task, unsigned int id) {
             upper = std::min(upper, split_upper);
         }
     }
-    if (lower > task.upperscope()) { return False; } // similar reason to check on line 169. If all children out of scope, 
+    if (lower > task.upperscope()) { return false; } // similar reason to check on line 169. If all children out of scope, 
                                                // and base risk out of scope, don't update bound.
     task.update(m_config, lower, upper, optimal_feature);
 }


### PR DESCRIPTION
Rui Xin, with much help from Chudi Zhong, found a bug where task erroneously updates to mark itself as fully resolved with a leaf objective: specifically, this happens when a task's leaf objective and the lower bounds for each split are all out of scope, but the lower bounds for some splits are still better than the leaf objective. This leads to missing some optimal trees, but is also a very quick fix!