### PR TITLE
Fix Feature Map Bugs

### DIFF
--- a/src/gosdt/_binarizer.py
+++ b/src/gosdt/_binarizer.py
@@ -291,10 +291,10 @@ class NumericBinarizer(TransformerMixin, BaseEstimator):
         check_is_fitted(self, ['n_features_in_', 'n_features_out_', 'column_values_', 'feature_names_in_'])
         
         # Create the feature map
-        ret = {}
+        ret = []
         idx = 0
         for i, col in enumerate(self.column_values_):
-            ret[i] = list(range(idx, idx + len(col) - 1))
+            ret.append(set(range(idx, idx + len(col) - 1)))
             idx += len(col) - 1
         return ret
     

--- a/src/gosdt/_tree.py
+++ b/src/gosdt/_tree.py
@@ -18,14 +18,14 @@ class Leaf:
 
 class Node:
 
-    def __init__(self, feature: int, left_child, right_child):
+    def __init__(self, feature: int, orig_feature: int, left_child, right_child):
         self.feature = feature
+        self.orig_feature = orig_feature
         self.left_child = left_child
         self.right_child = right_child
 
     def __str__(self) -> str:
-        return "{ feature: " + str(self.feature) + " [ left child: " + str(self.left_child) + ", right child: " + str(self.right_child) + "] }"
-
+        return "{ feature: " + str(self.feature) + ", orig feature: " +str(self.orig_feature) + ", [ left child: " + str(self.left_child) + ", right child: " + str(self.right_child) + "] }"
 
 class Tree:
     # Left is TRUE, Right is FALSE
@@ -43,7 +43,8 @@ class Tree:
             left_child = create_tree(json_object["true"])
             right_child = create_tree(json_object["false"])
             feature = json_object["feature"]
-            return Node(feature, left_child, right_child)
+            orig_feature = json_object["orig_feature"]
+            return Node(feature, orig_feature, left_child, right_child)
 
         self.tree = create_tree(json_result)
         self.features = features

--- a/src/libgosdt/include/model.hpp
+++ b/src/libgosdt/include/model.hpp
@@ -73,7 +73,6 @@ class Model {
     void to_json(json &node, const Dataset &dataset) const;
     void _to_json(json &node, const Dataset &dataset) const;
 
-    void decode_json(const Dataset &dataset, json &node) const;
     void translate_json(json &node, translation_type const &main, translation_type const &alternative,
                         unsigned int n_features) const;
 

--- a/src/libgosdt/src/model.cpp
+++ b/src/libgosdt/src/model.cpp
@@ -217,7 +217,6 @@ void Model::summarize(json &node) const {
 
 void Model::to_json(json &node, const Dataset &dataset) const {
     _to_json(node, dataset);
-    decode_json(dataset, node);
     // Convert to N-ary
     if (dataset.m_config.non_binary) {
         summarize(node);
@@ -231,6 +230,7 @@ void Model::_to_json(json &node, const Dataset &dataset) const {
         node["complexity"] = dataset.m_config.regularization;
     } else {
         node["feature"] = this->binary_feature;
+        node["orig_feature"] = this->feature;
         node["false"] = json::object();
         node["true"] = json::object();
         this->negative->_to_json(node["false"], dataset);
@@ -281,17 +281,5 @@ void Model::translate_json(json &node, translation_type const &main, translation
             node["false"] = node["swap"];
             node.erase("swap");
         }
-    }
-}
-
-void Model::decode_json(const Dataset &dataset, json &node) const {
-    if (node.contains("feature")) {
-        // index decoding from binary feature to original feature space
-        unsigned int binary_feature_index = node["feature"];
-        size_t feature_index = dataset.original_feature(binary_feature_index);
-
-        node["feature"] = feature_index;
-        decode_json(dataset, node["false"]);
-        decode_json(dataset, node["true"]);
     }
 }


### PR DESCRIPTION
Bug fix 1: When Dataset is given a non-trivial feature map, the resulting tree from GOSDT provides splits in terms of original-feature index. But this given index is used by the predict function to split. So we should give the post binarization index. 
Bug fix 2: Incompatible feature map format between binarizer and GOSDT.