### PR TITLE
Fix: using update variable in dispatch::exploit so parents are only updated when necessary

### DIFF
--- a/src/libgosdt/src/dispatch/dispatch.cpp
+++ b/src/libgosdt/src/dispatch/dispatch.cpp
@@ -64,7 +64,7 @@ bool Optimizer::dispatch(Message const &message, unsigned int id) {
             bool is_root = vertex->second.capture_set().count() == vertex->second.capture_set().size();
             if (is_root) {  // Update the optimizer state
                 global_update = update_root(vertex->second.lowerbound(), vertex->second.upperbound());
-            } else {
+            } else if (update) {
                 adjacency_accessor parents;  // find backward look-up entry
                 load_parents(identifier, parents);
                 signal_exploiters(parents, vertex->second, id);  // Signal parents


### PR DESCRIPTION
I think the improvement in runtime in iris.py and compas.py is trivial. Assuming tree size < 10 the improvement will be constant time too. But it saves on some GOSDT iterations (doesn't propagate updates to root if it doesn't have to). 